### PR TITLE
Feature: Improve robustness of MCAP Parser

### DIFF
--- a/src/modaq_toolkit/__init__.py
+++ b/src/modaq_toolkit/__init__.py
@@ -2,7 +2,7 @@
 MODAQ Toolkit: High-performance MODAQ to Parquet converter and analysis toolkit
 """
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 from .message_processing import (
     MessageProcessor,

--- a/src/modaq_toolkit/__init__.py
+++ b/src/modaq_toolkit/__init__.py
@@ -13,11 +13,11 @@ from .message_processing import (
 from .parser import MCAPParser, process_mcap_dir_to_dataframes, process_mcap_files
 
 __all__ = [
-    "MessageProcessor",
     "MCAPParser",
-    "parse_ros_message_definition",
+    "MessageProcessor",
     "expand_array_columns_vertically",
     "is_array_column",
-    "process_mcap_files",
+    "parse_ros_message_definition",
     "process_mcap_dir_to_dataframes",
+    "process_mcap_files",
 ]

--- a/src/modaq_toolkit/cli.py
+++ b/src/modaq_toolkit/cli.py
@@ -36,12 +36,53 @@ def main(args: list[str] | None = None) -> int:
         default=False,
         help="Enable asynchronous processing of MCAP files (default: False)",
     )
+    parser.add_argument(
+        "--skip-topics",
+        dest="topics_to_skip",
+        type=str,
+        nargs="*",
+        default=None,
+        help="List of topic names to skip during processing (space-separated)",
+    )
+    parser.add_argument(
+        "--stage1",
+        dest="process_stage1",
+        type=lambda x: x.lower() == "true",
+        default=False,
+        help="Process stage 1 output (one-to-one ROS message structure). Default: False",
+    )
+    parser.add_argument(
+        "--stage2",
+        dest="process_stage2",
+        type=lambda x: x.lower() == "true",
+        default=True,
+        help="Process stage 2 output (unpacked arrays for analysis). Default: True",
+    )
+    parser.add_argument(
+        "--stage1-dir",
+        dest="stage1_dir",
+        type=str,
+        default="a1_one_to_one",
+        help="Directory name for stage 1 output (default: a1_one_to_one)",
+    )
+    parser.add_argument(
+        "--stage2-dir",
+        dest="stage2_dir",
+        type=str,
+        default="a2_unpacked",
+        help="Directory name for stage 2 output (default: a2_unpacked)",
+    )
 
     parsed_args = parser.parse_args(args)
     process_mcap_files(
         parsed_args.input_dir,
         parsed_args.output_dir,
         async_processing=parsed_args.async_processing,
+        topics_to_skip=parsed_args.topics_to_skip,
+        process_stage1=parsed_args.process_stage1,
+        process_stage2=parsed_args.process_stage2,
+        stage1_dir=parsed_args.stage1_dir,
+        stage2_dir=parsed_args.stage2_dir,
     )
     return 0
 

--- a/src/modaq_toolkit/message_processing.py
+++ b/src/modaq_toolkit/message_processing.py
@@ -155,18 +155,138 @@ def expand_array_columns_vertically(df):
     return result_df
 
 
+# Original custom schema parsing implementation
+# Replaced with library-based version below for better reliability and maintainability
+# def parse_ros_message_definition(
+#     definition: str | bytes, _all_sections: list[str] | None = None
+# ) -> dict[str, Any]:
+#     """Parse a ROS message definition into a dictionary describing the message structure.
+#
+#     Args:
+#         definition: The ROS message definition string or bytes
+#         _all_sections: Internal parameter - full list of all schema sections for recursive lookups
+#
+#     Returns:
+#         Dictionary mapping field names to their specifications
+#     """
+#     if isinstance(definition, bytes):
+#         try:
+#             definition_str = definition.decode("utf-8")
+#         except UnicodeDecodeError:
+#             try:
+#                 definition_str = definition.decode("ascii")
+#             except UnicodeDecodeError:
+#                 definition_str = definition.decode("latin-1")
+#     else:
+#         definition_str = definition
+#
+#     # ROS message constant definitions to skip (not actual message fields)
+#     ROS_CONSTANTS = {
+#         "DEBUG=10",
+#         "INFO=20",
+#         "WARN=30",
+#         "ERROR=40",
+#         "FATAL=50",
+#     }
+#
+#     message_spec: dict[str, dict] = {}
+#
+#     # Split into sections on first call, or use existing sections
+#     if _all_sections is None:
+#         sections = definition_str.split(
+#             "================================================================================"
+#         )
+#         _all_sections = sections  # Preserve all sections for recursive calls
+#     else:
+#         sections = [definition_str]  # For recursive calls, only parse main section
+#
+#     main_section = sections[0].strip()
+#
+#     for line in main_section.split("\n"):
+#         line = line.strip()
+#         if not line or line.startswith("#"):
+#             continue
+#
+#         parts = line.split()
+#         if len(parts) >= 2:
+#             field_type, field_name = parts[0], parts[1]
+#
+#             # Skip known ROS logging level constants
+#             if field_name in ROS_CONSTANTS:
+#                 logger.debug(f"Skipping ROS constant: {field_name}")
+#                 continue
+#
+#             is_array = field_type.endswith("[]")
+#             if is_array:
+#                 field_type = field_type[:-2]
+#
+#             default_value = None
+#             if len(parts) >= 3:
+#                 try:
+#                     raw_default = parts[2].strip('"')
+#                     if field_type == "bool":
+#                         default_value = raw_default.lower() == "true"
+#                     elif field_type == "string":
+#                         default_value = raw_default
+#                     elif field_type.startswith("float"):
+#                         default_value = float(raw_default)
+#                     elif field_type.startswith("int"):
+#                         default_value = int(raw_default)
+#                 except:
+#                     pass
+#
+#             message_spec[field_name] = {
+#                 "type": field_type,
+#                 "is_array": is_array,
+#                 "default": default_value,
+#             }
+#
+#             # For nested types (e.g., std_msgs/Header, builtin_interfaces/Time),
+#             # search ALL available sections to find the type definition
+#             if "/" in field_type:
+#                 type_name = field_type.split("/")[-1]
+#                 for section in _all_sections[
+#                     1:
+#                 ]:  # Use all sections, not just local ones
+#                     if f"MSG: {field_type}" in section:
+#                         # Pass all sections to recursive call so deeply nested types can be found
+#                         nested_fields = parse_ros_message_definition(
+#                             section, _all_sections
+#                         )
+#                         message_spec[field_name]["fields"] = nested_fields
+#                         break
+#
+#     return message_spec
+
+
 def parse_ros_message_definition(
     definition: str | bytes, _all_sections: list[str] | None = None
 ) -> dict[str, Any]:
     """Parse a ROS message definition into a dictionary describing the message structure.
 
+    This implementation uses the MCAP library's built-in rosidl_adapter parser
+    instead of custom regex-based parsing for better reliability and maintainability.
+
     Args:
         definition: The ROS message definition string or bytes
-        _all_sections: Internal parameter - full list of all schema sections for recursive lookups
+        _all_sections: Internal parameter - kept for API compatibility but not used
+                      (the library parser handles multi-section schemas internally)
 
     Returns:
-        Dictionary mapping field names to their specifications
+        Dictionary mapping field names to their specifications, with structure:
+        {
+            "field_name": {
+                "type": "type_name",
+                "is_array": bool,
+                "default": value or None,
+                "fields": {...}  # For nested types only
+            }
+        }
     """
+    from mcap_ros2._dynamic import _for_each_msgdef
+    from mcap_ros2._vendor.rosidl_adapter.parser import MessageSpecification
+
+    # Convert bytes to string if needed
     if isinstance(definition, bytes):
         try:
             definition_str = definition.decode("utf-8")
@@ -178,83 +298,71 @@ def parse_ros_message_definition(
     else:
         definition_str = definition
 
-    # ROS message constant definitions to skip (not actual message fields)
-    ROS_CONSTANTS = {
-        "DEBUG=10",
-        "INFO=20",
-        "WARN=30",
-        "ERROR=40",
-        "FATAL=50",
-    }
+    # Extract schema name from the first line or use a default
+    # The schema name is needed by _for_each_msgdef but in our use case
+    # we only care about the main (first) message definition
 
-    message_spec: dict[str, dict] = {}
+    # Use a placeholder schema name - the library will parse all sections
+    # and we'll just take the first one (which is the main message)
+    schema_name = "parsed/Message"
 
-    # Split into sections on first call, or use existing sections
-    if _all_sections is None:
-        sections = definition_str.split(
-            "================================================================================"
-        )
-        _all_sections = sections  # Preserve all sections for recursive calls
+    # Use the MCAP library's parser to handle all sections
+    all_msgdefs: dict[str, MessageSpecification] = {}
+    first_schema_name = None
+
+    def collect_msgdef(
+        cur_schema_name: str, short_name: str, msgdef: MessageSpecification
+    ):
+        """Collect all message definitions found in the schema."""
+        nonlocal first_schema_name
+        if first_schema_name is None:
+            first_schema_name = cur_schema_name
+        all_msgdefs[cur_schema_name] = msgdef
+        all_msgdefs[short_name] = msgdef
+
+    # Parse the schema using the library's built-in parser
+    _for_each_msgdef(schema_name, definition_str, collect_msgdef)
+
+    # Get the main message definition (the first one parsed)
+    # The first message parsed is always the main/top-level message
+    if not all_msgdefs:
+        # Empty schema
+        return {}
+
+    if first_schema_name and first_schema_name in all_msgdefs:
+        main_msgdef = all_msgdefs[first_schema_name]
     else:
-        sections = [definition_str]  # For recursive calls, only parse main section
+        # Fallback to first in dict
+        main_msgdef = next(iter(all_msgdefs.values()))
 
-    main_section = sections[0].strip()
+    def field_to_dict(field) -> dict[str, Any]:
+        """Convert a Field object to our dictionary format."""
+        # Build the type string (with package name if present)
+        if field.type.pkg_name:
+            type_str = f"{field.type.pkg_name}/{field.type.type}"
+        else:
+            type_str = field.type.type
 
-    for line in main_section.split("\n"):
-        line = line.strip()
-        if not line or line.startswith("#"):
-            continue
+        spec = {
+            "type": type_str,
+            "is_array": field.type.is_array,
+            "default": field.default_value,
+        }
 
-        parts = line.split()
-        if len(parts) >= 2:
-            field_type, field_name = parts[0], parts[1]
+        # Recursively handle nested types
+        if not field.type.is_primitive_type():
+            nested_key = f"{field.type.pkg_name}/{field.type.type}"
+            if nested_key in all_msgdefs:
+                nested_msgdef = all_msgdefs[nested_key]
+                spec["fields"] = {
+                    nested_field.name: field_to_dict(nested_field)
+                    for nested_field in nested_msgdef.fields
+                }
 
-            # Skip known ROS logging level constants
-            if field_name in ROS_CONSTANTS:
-                logger.debug(f"Skipping ROS constant: {field_name}")
-                continue
+        return spec
 
-            is_array = field_type.endswith("[]")
-            if is_array:
-                field_type = field_type[:-2]
-
-            default_value = None
-            if len(parts) >= 3:
-                try:
-                    raw_default = parts[2].strip('"')
-                    if field_type == "bool":
-                        default_value = raw_default.lower() == "true"
-                    elif field_type == "string":
-                        default_value = raw_default
-                    elif field_type.startswith("float"):
-                        default_value = float(raw_default)
-                    elif field_type.startswith("int"):
-                        default_value = int(raw_default)
-                except:
-                    pass
-
-            message_spec[field_name] = {
-                "type": field_type,
-                "is_array": is_array,
-                "default": default_value,
-            }
-
-            # For nested types (e.g., std_msgs/Header, builtin_interfaces/Time),
-            # search ALL available sections to find the type definition
-            if "/" in field_type:
-                type_name = field_type.split("/")[-1]
-                for section in _all_sections[
-                    1:
-                ]:  # Use all sections, not just local ones
-                    if f"MSG: {field_type}" in section:
-                        # Pass all sections to recursive call so deeply nested types can be found
-                        nested_fields = parse_ros_message_definition(
-                            section, _all_sections
-                        )
-                        message_spec[field_name]["fields"] = nested_fields
-                        break
-
-    return message_spec
+    # Convert all fields to our dictionary format
+    return {field.name: field_to_dict(field) for field in main_msgdef.fields}
 
 
 class MessageProcessor:

--- a/src/modaq_toolkit/message_processing.py
+++ b/src/modaq_toolkit/message_processing.py
@@ -126,8 +126,18 @@ def expand_array_columns_vertically(df):
     return result_df
 
 
-def parse_ros_message_definition(definition: str | bytes) -> dict[str, Any]:
-    """Parse a ROS message definition into a dictionary describing the message structure."""
+def parse_ros_message_definition(
+    definition: str | bytes, _all_sections: list[str] | None = None
+) -> dict[str, Any]:
+    """Parse a ROS message definition into a dictionary describing the message structure.
+
+    Args:
+        definition: The ROS message definition string or bytes
+        _all_sections: Internal parameter - full list of all schema sections for recursive lookups
+
+    Returns:
+        Dictionary mapping field names to their specifications
+    """
     if isinstance(definition, bytes):
         try:
             definition_str = definition.decode("utf-8")

--- a/src/modaq_toolkit/message_processing.py
+++ b/src/modaq_toolkit/message_processing.py
@@ -159,9 +159,16 @@ def parse_ros_message_definition(
     }
 
     message_spec: dict[str, dict] = {}
-    sections = definition_str.split(
-        "================================================================================"
-    )
+
+    # Split into sections on first call, or use existing sections
+    if _all_sections is None:
+        sections = definition_str.split(
+            "================================================================================"
+        )
+        _all_sections = sections  # Preserve all sections for recursive calls
+    else:
+        sections = [definition_str]  # For recursive calls, only parse main section
+
     main_section = sections[0].strip()
 
     for line in main_section.split("\n"):
@@ -203,11 +210,18 @@ def parse_ros_message_definition(
                 "default": default_value,
             }
 
+            # For nested types (e.g., std_msgs/Header, builtin_interfaces/Time),
+            # search ALL available sections to find the type definition
             if "/" in field_type:
                 type_name = field_type.split("/")[-1]
-                for section in sections[1:]:
+                for section in _all_sections[
+                    1:
+                ]:  # Use all sections, not just local ones
                     if f"MSG: {field_type}" in section:
-                        nested_fields = parse_ros_message_definition(section)
+                        # Pass all sections to recursive call so deeply nested types can be found
+                        nested_fields = parse_ros_message_definition(
+                            section, _all_sections
+                        )
                         message_spec[field_name]["fields"] = nested_fields
                         break
 

--- a/src/modaq_toolkit/message_processing.py
+++ b/src/modaq_toolkit/message_processing.py
@@ -129,6 +129,15 @@ def parse_ros_message_definition(definition: str | bytes) -> dict[str, Any]:
     else:
         definition_str = definition
 
+    # ROS message constant definitions to skip (not actual message fields)
+    ROS_CONSTANTS = {
+        "DEBUG=10",
+        "INFO=20",
+        "WARN=30",
+        "ERROR=40",
+        "FATAL=50",
+    }
+
     message_spec: dict[str, dict] = {}
     sections = definition_str.split(
         "================================================================================"
@@ -143,6 +152,12 @@ def parse_ros_message_definition(definition: str | bytes) -> dict[str, Any]:
         parts = line.split()
         if len(parts) >= 2:
             field_type, field_name = parts[0], parts[1]
+
+            # Skip known ROS logging level constants
+            if field_name in ROS_CONSTANTS:
+                logger.debug(f"Skipping ROS constant: {field_name}")
+                continue
+
             is_array = field_type.endswith("[]")
             if is_array:
                 field_type = field_type[:-2]

--- a/src/modaq_toolkit/message_processing.py
+++ b/src/modaq_toolkit/message_processing.py
@@ -21,15 +21,27 @@ def _normalize_to_array(value):
 
     Returns None for values that should be skipped (empty arrays, None, NaN).
     Returns a list/array for valid values.
+
+    This preserves preserves numpy scalar dtypes (e.g., np.uint64, np.int32) to maintain
+    ROS type precision in the output data.
+
+    Note: Do NOT call .item() on numpy scalars as this converts them back to
+    Python types and loses dtype information.
     """
     # Handle None/NaN
     if value is None or (isinstance(value, float) and np.isnan(value)):
         return None
 
-    # Handle numpy scalars (from type conversion) - extract Python value
-    if isinstance(value, np.generic) or (
-        isinstance(value, np.ndarray) and value.ndim == 0
-    ):
+    # Handle numpy scalars (from type conversion) - preserve dtype
+    if isinstance(value, np.generic):
+        # Keep numpy scalar wrapped in list to preserve dtype
+        # e.g., [np.float32(3.14)] not [3.14] (Python float)
+        return [value]
+
+    # Handle 0-dimensional numpy arrays
+    if isinstance(value, np.ndarray) and value.ndim == 0:
+        # Extract scalar value from 0-d array
+        # Note: 0-d arrays have already lost their context, so .item() is acceptable here
         return [value.item()]
 
     # Already an array or list

--- a/src/modaq_toolkit/message_processing.py
+++ b/src/modaq_toolkit/message_processing.py
@@ -133,4 +133,13 @@ class MessageProcessor:
         df = pd.DataFrame(self.messages)
         if "sec" in df.columns and "nanosec" in df.columns:
             df["timestamp"] = df["sec"] + df["nanosec"] * 1e-9
+
+        if "stamp" in df.columns:
+            df["sec"] = df["stamp"].apply(lambda t: t.sec)
+            df["nanosec"] = df["stamp"].apply(lambda t: t.nanosec)
+
+            df = df.drop(columns=["stamp"])
+
+            df["timestamp"] = df["sec"] + df["nanosec"] * 1e-9
+
         return df

--- a/src/modaq_toolkit/message_processing.py
+++ b/src/modaq_toolkit/message_processing.py
@@ -38,7 +38,19 @@ def _normalize_to_array(value):
 
 
 def expand_array_columns_vertically(df):
-    """Expands all columns containing arrays vertically, creating new rows for each array element."""
+    """Expands all columns containing arrays vertically, creating new rows for each array element.
+
+    Preservation strategy:
+    - Converts scalars to [scalar]
+    - Keeps non-empty arrays as-is
+    - Skips empty arrays []
+    - Concatenates all values vertically across all rows
+    - One observation per cell (no nested arrays)
+    """
+    # Early exit for empty DataFrame
+    if df.empty:
+        return df
+
     array_columns = []
     non_array_columns = []
     for col in df.columns:
@@ -51,19 +63,56 @@ def expand_array_columns_vertically(df):
     if not array_columns:
         return df
 
-    expanded_data = []
-    for idx, row in df.iterrows():
-        array_length = len(row[array_columns[0]])
-        for i in range(array_length):
-            new_row = {}
-            for col in non_array_columns:
-                new_row[col] = row[col]
-            for col in array_columns:
-                new_row[col] = row[col][i]
-            expanded_data.append(new_row)
+    # Collect all array values across all rows for each array column
+    # This implements the concatenation strategy: [a, b], [], [c] -> [a, b, c]
+    all_arrays = {col: [] for col in array_columns}
+    non_array_values = {col: [] for col in non_array_columns}
 
-    result_df = pd.DataFrame(expanded_data)
-    logger.debug(f"Expanded shape from {df.shape} to {result_df.shape}")
+    for idx, row in df.iterrows():
+        # Normalize each array column value
+        normalized_arrays = {}
+        for col in array_columns:
+            normalized = _normalize_to_array(row[col])
+            normalized_arrays[col] = normalized
+
+        # Check if all array columns are None (should skip this row entirely)
+        if all(arr is None for arr in normalized_arrays.values()):
+            logger.debug(f"Skipping row {idx}: all array columns are empty")
+            continue
+
+        # Get the maximum length among non-None arrays in this row
+        lengths = [len(arr) for arr in normalized_arrays.values() if arr is not None]
+        if not lengths:
+            continue
+
+        max_length = max(lengths)
+
+        # Validate: all non-None arrays should have the same length
+        if not all(length == max_length for length in lengths):
+            logger.warning(f"Row {idx} has arrays of inconsistent lengths: {lengths}, skipping")
+            continue
+
+        # Concatenate this row's arrays to the master list
+        for col in array_columns:
+            if normalized_arrays[col] is not None:
+                all_arrays[col].extend(normalized_arrays[col])
+            else:
+                # If one column is None but others aren't, pad with NaN
+                all_arrays[col].extend([np.nan] * max_length)
+
+        # Repeat non-array values to match array length
+        for col in non_array_columns:
+            non_array_values[col].extend([row[col]] * max_length)
+
+    # Build the result DataFrame
+    result_data = {}
+    for col in non_array_columns:
+        result_data[col] = non_array_values[col]
+    for col in array_columns:
+        result_data[col] = all_arrays[col]
+
+    result_df = pd.DataFrame(result_data)
+    logger.info(f"Expanded shape from {df.shape} to {result_df.shape}")
     return result_df
 
 

--- a/src/modaq_toolkit/message_processing.py
+++ b/src/modaq_toolkit/message_processing.py
@@ -26,6 +26,12 @@ def _normalize_to_array(value):
     if value is None or (isinstance(value, float) and np.isnan(value)):
         return None
 
+    # Handle numpy scalars (from type conversion) - extract Python value
+    if isinstance(value, np.generic) or (
+        isinstance(value, np.ndarray) and value.ndim == 0
+    ):
+        return [value.item()]
+
     # Already an array or list
     if isinstance(value, (np.ndarray, list)):
         # Skip empty arrays

--- a/src/modaq_toolkit/message_processing.py
+++ b/src/modaq_toolkit/message_processing.py
@@ -94,9 +94,13 @@ def expand_array_columns_vertically(df):
         max_length = max(lengths)
 
         # Validate: all non-None arrays should have the same length
+        # This is a data integrity check - inconsistent array lengths indicate
+        # corrupted data or transmission errors that must be investigated
         if not all(length == max_length for length in lengths):
-            logger.warning(f"Row {idx} has arrays of inconsistent lengths: {lengths}, skipping")
-            continue
+            raise ValueError(
+                f"Data integrity error at row {idx}: Array columns have inconsistent lengths {lengths}. "
+                f"All nested arrays in a ROS message must have the same length. "
+            )
 
         # Concatenate this row's arrays to the master list
         for col in array_columns:

--- a/src/modaq_toolkit/message_processing.py
+++ b/src/modaq_toolkit/message_processing.py
@@ -246,67 +246,107 @@ class MessageProcessor:
             "uint64": np.uint64,
         }
 
+    def _apply_type_conversion(self, value: Any, ros_type: str) -> Any:
+        """Apply numpy type conversion if the ROS type is in the conversion map.
+
+        Args:
+            value: The value to convert (can be scalar or array)
+            ros_type: The ROS type string (e.g., "float64", "uint32")
+
+        Returns:
+            For scalars: numpy scalar with correct dtype (e.g., np.int32(5))
+            For arrays: numpy array with correct dtype
+            Otherwise: original value unchanged
+        """
+        if ros_type in self.ros_type_to_numpy_type_map:
+            numpy_dtype = self.ros_type_to_numpy_type_map[ros_type]
+
+            # Check if value is already an array/list
+            if isinstance(value, (list, np.ndarray)):
+                return np.array(value, dtype=numpy_dtype)
+            else:
+                # For scalars, return numpy scalar type (not wrapped in array)
+                # This ensures pandas can properly infer column dtype
+                return numpy_dtype(value)
+        return value
+
+    def _extract_nested_fields(
+        self, msg_obj: Any, field_spec: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Recursively extract fields from nested ROS message types.
+
+        This method handles complex message types like std_msgs/Header or
+        builtin_interfaces/Time by walking through their nested field structure
+        defined in the schema and extracting values from the message object.
+
+        Args:
+            msg_obj: The ROS message object to extract fields from
+            field_spec: The schema specification for this field (must have "fields" key)
+
+        Returns:
+            Dictionary mapping field names to their values (with type conversion applied)
+
+        Example:
+            For a header field with stamp (builtin_interfaces/Time), this extracts:
+            {
+                "sec": 1234567890,
+                "nanosec": 123456789,
+                "frame_id": "base_link"
+            }
+        """
+        result = {}
+
+        if "fields" not in field_spec:
+            return result
+
+        nested_fields = field_spec["fields"]
+
+        for nested_name, nested_spec in nested_fields.items():
+            # Skip MSG: marker entries (these are just schema metadata)
+            if nested_spec.get("type", "").startswith("MSG:"):
+                continue
+
+            try:
+                nested_value = getattr(msg_obj, nested_name)
+                nested_type = nested_spec.get("type")
+
+                # Recursively handle nested types (e.g., stamp is builtin_interfaces/Time)
+                if "fields" in nested_spec:
+                    sub_fields = self._extract_nested_fields(nested_value, nested_spec)
+                    result.update(sub_fields)
+                else:
+                    result[nested_name] = self._apply_type_conversion(
+                        nested_value, nested_type
+                    )
+
+            except (AttributeError, RuntimeError) as e:
+                logger.warning(f"Failed to extract nested field '{nested_name}': {e}")
+
+        return result
+
     def process_message(self, msg: Any) -> None:
+        """Process a ROS message and extract all fields according to the schema.
+
+        Handles both simple fields and nested message types (like std_msgs/Header).
+        Applies numpy type conversion based on the schema's ROS type definitions.
+        """
         message_dict = {}
-        # print(self.schema)
-        # Typical entry
-        # data = {
-        #     "header": {
-        #         "type": "std_msgs/Header",
-        #         "is_array": False,
-        #         "default": None,
-        #         "fields": {
-        #             "std_msgs/Header": {
-        #                 "type": "MSG:",
-        #                 "is_array": False,
-        #                 "default": None,
-        #             },
-        #             "stamp": {
-        #                 "type": "builtin_interfaces/Time",
-        #                 "is_array": False,
-        #                 "default": None,
-        #             },
-        #             "frame_id": {
-        #                 "type": "string",
-        #                 "is_array": False,
-        #                 "default": None,
-        #             },
-        #         },
-        #     },
-        #     "ain0": {"type": "float64", "is_array": True, "default": None},
-        #     "ain1": {"type": "float64", "is_array": True, "default": None},
-        #     "ain2": {"type": "float64", "is_array": True, "default": None},
-        #     "ain3": {"type": "float64", "is_array": True, "default": None},
-        #     "ain4": {"type": "float64", "is_array": True, "default": None},
-        #     "ain5": {"type": "float64", "is_array": True, "default": None},
-        #     "ain6": {"type": "float64", "is_array": True, "default": None},
-        #     "ain7": {"type": "float64", "is_array": True, "default": None},
-        #     "core_timer": {"type": "uint64", "is_array": True, "default": None},
-        #     "system_time": {"type": "uint64", "is_array": True, "default": None},
-        # }
-        if "header" in self.schema:
-            message_dict["sec"] = msg.header.stamp.sec
-            message_dict["nanosec"] = msg.header.stamp.nanosec
-            message_dict["frame_id"] = msg.header.frame_id
 
         for field_name, field_spec in self.schema.items():
-            if field_name == "header":
-                continue
             try:
                 value = getattr(msg, field_name)
-
-                # Get the type from field_spec
                 field_type = field_spec.get("type")
 
-                # Try to convert to numpy type if applicable
-                if field_type in self.ros_type_to_numpy_type_map:
-                    numpy_dtype = self.ros_type_to_numpy_type_map[field_type]
-                    print(
-                        "Converting field:", field_name, "to numpy dtype:", numpy_dtype
-                    )
-                    message_dict[field_name] = np.array(value, dtype=numpy_dtype)
+                # Check if this field has nested structure (e.g., header, pose, etc.)
+                if "fields" in field_spec:
+                    # Extract nested fields and flatten into message_dict
+                    nested_data = self._extract_nested_fields(value, field_spec)
+                    message_dict.update(nested_data)
                 else:
-                    message_dict[field_name] = value
+                    # Simple field - apply type conversion
+                    message_dict[field_name] = self._apply_type_conversion(
+                        value, field_type
+                    )
 
             except (AttributeError, RuntimeError) as e:
                 logger.warning(f"Failed to get field '{field_name}': {e}")

--- a/src/modaq_toolkit/message_processing.py
+++ b/src/modaq_toolkit/message_processing.py
@@ -16,6 +16,27 @@ def is_array_column(series):
     return False
 
 
+def _normalize_to_array(value):
+    """Normalize a value to an array, handling scalars and empty arrays.
+
+    Returns None for values that should be skipped (empty arrays, None, NaN).
+    Returns a list/array for valid values.
+    """
+    # Handle None/NaN
+    if value is None or (isinstance(value, float) and np.isnan(value)):
+        return None
+
+    # Already an array or list
+    if isinstance(value, (np.ndarray, list)):
+        # Skip empty arrays
+        if len(value) == 0:
+            return None
+        return value
+
+    # Scalar value - wrap in list
+    return [value]
+
+
 def expand_array_columns_vertically(df):
     """Expands all columns containing arrays vertically, creating new rows for each array element."""
     array_columns = []

--- a/src/modaq_toolkit/message_processing.py
+++ b/src/modaq_toolkit/message_processing.py
@@ -116,6 +116,42 @@ class MessageProcessor:
 
     def process_message(self, msg: Any) -> None:
         message_dict = {}
+        # print(self.schema)
+        # Typical entry
+        # data = {
+        #     "header": {
+        #         "type": "std_msgs/Header",
+        #         "is_array": False,
+        #         "default": None,
+        #         "fields": {
+        #             "std_msgs/Header": {
+        #                 "type": "MSG:",
+        #                 "is_array": False,
+        #                 "default": None,
+        #             },
+        #             "stamp": {
+        #                 "type": "builtin_interfaces/Time",
+        #                 "is_array": False,
+        #                 "default": None,
+        #             },
+        #             "frame_id": {
+        #                 "type": "string",
+        #                 "is_array": False,
+        #                 "default": None,
+        #             },
+        #         },
+        #     },
+        #     "ain0": {"type": "float64", "is_array": True, "default": None},
+        #     "ain1": {"type": "float64", "is_array": True, "default": None},
+        #     "ain2": {"type": "float64", "is_array": True, "default": None},
+        #     "ain3": {"type": "float64", "is_array": True, "default": None},
+        #     "ain4": {"type": "float64", "is_array": True, "default": None},
+        #     "ain5": {"type": "float64", "is_array": True, "default": None},
+        #     "ain6": {"type": "float64", "is_array": True, "default": None},
+        #     "ain7": {"type": "float64", "is_array": True, "default": None},
+        #     "core_timer": {"type": "uint64", "is_array": True, "default": None},
+        #     "system_time": {"type": "uint64", "is_array": True, "default": None},
+        # }
         if "header" in self.schema:
             message_dict["sec"] = msg.header.stamp.sec
             message_dict["nanosec"] = msg.header.stamp.nanosec

--- a/src/modaq_toolkit/message_processing.py
+++ b/src/modaq_toolkit/message_processing.py
@@ -234,15 +234,15 @@ class MessageProcessor:
         self.messages: list[dict[str, Any]] = []
 
         self.ros_type_to_numpy_type_map = {
-            # "float32": np.float32,
+            "float32": np.float32,
             "float64": np.float64,
-            # "int8": np.int8,
-            # "int16": np.int16,
-            # "int32": np.int32,
-            # "int64": np.int64,
-            # "uint8": np.uint8,
-            # "uint16": np.uint16,
-            # "uint32": np.uint32,
+            "int8": np.int8,
+            "int16": np.int16,
+            "int32": np.int32,
+            "int64": np.int64,
+            "uint8": np.uint8,
+            "uint16": np.uint16,
+            "uint32": np.uint32,
             "uint64": np.uint64,
         }
 

--- a/src/modaq_toolkit/message_processing.py
+++ b/src/modaq_toolkit/message_processing.py
@@ -134,6 +134,23 @@ def expand_array_columns_vertically(df):
         result_data[col] = all_arrays[col]
 
     result_df = pd.DataFrame(result_data)
+
+    # Preserve dtypes from original DataFrame
+    # When repeating values, pandas may upcast types (e.g., int32 -> int64)
+    # We need to explicitly restore the original dtypes
+    for col in df.columns:
+        if col in result_df.columns:
+            original_dtype = df[col].dtype
+            # Only apply dtype if it's not object (which might contain arrays/complex types)
+            if original_dtype != "object" and result_df[col].dtype != original_dtype:
+                try:
+                    result_df[col] = result_df[col].astype(original_dtype)
+                except (ValueError, TypeError):
+                    # If conversion fails, keep the inferred dtype
+                    logger.debug(
+                        f"Could not preserve dtype {original_dtype} for column {col}"
+                    )
+
     logger.info(f"Expanded shape from {df.shape} to {result_df.shape}")
     return result_df
 

--- a/src/modaq_toolkit/message_processing.py
+++ b/src/modaq_toolkit/message_processing.py
@@ -114,6 +114,19 @@ class MessageProcessor:
         self.schema = schema
         self.messages: list[dict[str, Any]] = []
 
+        self.ros_type_to_numpy_type_map = {
+            # "float32": np.float32,
+            "float64": np.float64,
+            # "int8": np.int8,
+            # "int16": np.int16,
+            # "int32": np.int32,
+            # "int64": np.int64,
+            # "uint8": np.uint8,
+            # "uint16": np.uint16,
+            # "uint32": np.uint32,
+            "uint64": np.uint64,
+        }
+
     def process_message(self, msg: Any) -> None:
         message_dict = {}
         # print(self.schema)
@@ -160,8 +173,24 @@ class MessageProcessor:
         for field_name, field_spec in self.schema.items():
             if field_name == "header":
                 continue
-            value = getattr(msg, field_name)
-            message_dict[field_name] = value
+            try:
+                value = getattr(msg, field_name)
+
+                # Get the type from field_spec
+                field_type = field_spec.get("type")
+
+                # Try to convert to numpy type if applicable
+                if field_type in self.ros_type_to_numpy_type_map:
+                    numpy_dtype = self.ros_type_to_numpy_type_map[field_type]
+                    print(
+                        "Converting field:", field_name, "to numpy dtype:", numpy_dtype
+                    )
+                    message_dict[field_name] = np.array(value, dtype=numpy_dtype)
+                else:
+                    message_dict[field_name] = value
+
+            except (AttributeError, RuntimeError) as e:
+                logger.warning(f"Failed to get field '{field_name}': {e}")
 
         self.messages.append(message_dict)
 

--- a/src/modaq_toolkit/parser.py
+++ b/src/modaq_toolkit/parser.py
@@ -131,7 +131,10 @@ class MCAPParser:
                     )
 
     def _process_dataframe_for_stage2(
-        self, df: pd.DataFrame
+        self,
+        df: pd.DataFrame,
+        convert_ros_time_to_utc_datetime_index: bool = True,
+        remove_original_extra_time_columns: bool = True,
     ) -> tuple[pd.DataFrame, float]:
         """Process a dataframe for stage 2, returning the processed df and sample rate."""
         # Early exit for empty DataFrame
@@ -148,14 +151,46 @@ class MCAPParser:
             if df.empty:
                 return df, None
 
-            df["time"] = pd.to_datetime(
-                df["system_time"], origin="unix", unit="ns", utc=True
-            )
-            df = df.set_index("time")
-            df = df.drop(["sec", "nanosec", "frame_id", "timestamp"], axis="columns")
+            if convert_ros_time_to_utc_datetime_index:
+                # Create time index from available time columns
+                # Priority: system_time (high-res sensor data) > timestamp (header stamp)
+                if "system_time" in df.columns:
+                    df["time"] = pd.to_datetime(
+                        df["system_time"], origin="unix", unit="ns", utc=True
+                    )
+                    df = df.set_index("time")
+                    time_diffs = df.index.to_series().diff().dt.total_seconds()
+                    sample_rate = 1 / time_diffs.mean()
+                elif "timestamp" in df.columns:
+                    df["time"] = pd.to_datetime(
+                        df["timestamp"], origin="unix", unit="s", utc=True
+                    )
+                    df = df.set_index("time")
+                    time_diffs = df.index.to_series().diff().dt.total_seconds()
+                    sample_rate = 1 / time_diffs.mean()
+                else:
+                    logger.warning(
+                        f"No time column (system_time or timestamp) found after array expansion. "
+                        f"Skipping time indexing. Available columns: {df.columns.tolist()}"
+                    )
+                    sample_rate = None
 
-            time_diffs = df.index.to_series().diff().dt.total_seconds()
-            return df, 1 / time_diffs.mean()
+            if remove_original_extra_time_columns:
+                # Drop common time/header columns if they exist
+                cols_to_drop = [
+                    "sec",
+                    "nanosec",
+                    "frame_id",
+                    "timestamp",
+                    "system_time",
+                ]
+                existing_cols_to_drop = [
+                    col for col in cols_to_drop if col in df.columns
+                ]
+                if existing_cols_to_drop:
+                    df = df.drop(existing_cols_to_drop, axis="columns")
+
+            return df, sample_rate
         else:
             if "timestamp" not in df.columns:
                 logger.warning(
@@ -245,12 +280,20 @@ class MCAPParser:
                 f"  Latest ending topics: {', '.join(latest_end_topics)} at {latest_end}"
             )
 
-    def get_dataframes(self, process_stage2: bool = False) -> dict[str, pd.DataFrame]:
+    def get_dataframes(
+        self,
+        process_stage2: bool = False,
+        stage_2_convert_ros_time_to_utc_datetime_index: bool = True,
+        stage_2_remove_original_extra_time_columns: bool = True,
+    ) -> dict[str, pd.DataFrame]:
         """
         Return a dictionary of processed dataframes without saving to disk.
 
         Args:
             process_stage2: If True, process dataframes for stage 2 (expand arrays, etc.)
+            stage_2_convert_ros_time_to_utc_datetime_index: If True, convert ROS time (sec,nanosec) to UTC datetime index
+            stage_2_remove_original_extra_time_columns: If True, remove sec, nanosec, timestamp, system_time
+            columns from original dataframes
 
         Returns:
             A dictionary with topic names as keys and processed dataframes as values
@@ -271,7 +314,11 @@ class MCAPParser:
             logger.info(
                 f"Processing dataframe for topic: {topic} with shape {df.shape}"
             )
-            processed_df, _ = self._process_dataframe_for_stage2(df.copy())
+            processed_df, _ = self._process_dataframe_for_stage2(
+                df.copy(),
+                convert_ros_time_to_utc_datetime_index=stage_2_convert_ros_time_to_utc_datetime_index,
+                remove_original_extra_time_columns=stage_2_remove_original_extra_time_columns,
+            )
             logger.info(f"  Stage 2 Processed DataFrame shape: {processed_df.shape}")
 
             # Only include non-empty DataFrames in result

--- a/src/modaq_toolkit/parser.py
+++ b/src/modaq_toolkit/parser.py
@@ -653,25 +653,63 @@ def process_mcap_dir_to_dataframes(
     return result
 
 
-def process_single_file(mcap_file: Path, group: str, output_path: Path) -> None:
-    """Process a single MCAP file - this function runs in its own process."""
+def process_single_file(
+    mcap_file: Path,
+    group: str,
+    output_path: Path,
+    topics_to_skip: list[str] | None = None,
+    process_stage1: bool = True,
+    process_stage2: bool = True,
+    stage1_dir: str | Path = "a1_one_to_one",
+    stage2_dir: str | Path = "a2_unpacked",
+) -> None:
+    """
+    Process a single MCAP file - this function runs in its own process.
+
+    Args:
+        mcap_file: Path to the MCAP file to process
+        group: Group name for organizing output
+        output_path: Base output directory
+        topics_to_skip: Optional list of topic names to skip during processing
+        process_stage1: If True, process and save stage 1 output.
+                       Stage 1 preserves one-to-one ROS message structure where each row is
+                       a single ROS message. Array fields remain packed within rows.
+        process_stage2: If True, process and save stage 2 output.
+                       Stage 2 unpacks array fields into separate rows, where each array element
+                       becomes its own row. This format is recommended for analysis as it follows
+                       tidy data principles: each variable is a column, each observation is a row,
+                       and each value is a single cell.
+        stage1_dir: Directory name for stage 1 output (default: "a1_one_to_one")
+        stage2_dir: Directory name for stage 2 output (default: "a2_unpacked")
+    """
     logger.info(f"\nProcessing file {mcap_file.name} from group '{group}'")
+
+    # Convert to Path objects
+    stage1_path = Path(stage1_dir)
+    stage2_path = Path(stage2_dir)
 
     # Create group-specific output directories
     group_output = output_path / group
     group_metadata = group_output / "metadata"
-    (group_output / "a1_one_to_one").mkdir(parents=True, exist_ok=True)
-    (group_output / "a2_real_data").mkdir(parents=True, exist_ok=True)
+
+    if process_stage1:
+        (group_output / stage1_path).mkdir(parents=True, exist_ok=True)
+    if process_stage2:
+        (group_output / stage2_path).mkdir(parents=True, exist_ok=True)
+
     group_metadata.mkdir(parents=True, exist_ok=True)
 
-    parser = MCAPParser(mcap_file)
+    parser = MCAPParser(mcap_file, topics_to_skip=topics_to_skip)
     parser.read_mcap()
     original_dataframes = parser.dataframes.copy()
 
-    parser.create_output(group_output, stage="a1_one_to_one")
-    logger.info("Processing expanded arrays")
-    parser.dataframes = original_dataframes
-    parser.create_output(group_output, stage="a2_real_data")
+    if process_stage1:
+        parser.create_output(group_output, stage=str(stage1_path))
+
+    if process_stage2:
+        logger.info("Processing expanded arrays")
+        parser.dataframes = original_dataframes
+        parser.create_output(group_output, stage=str(stage2_path))
 
     logger.info(f"Completed processing {mcap_file.name}\n")
     return mcap_file.name
@@ -681,8 +719,25 @@ async def process_mcap_files_parallel(
     mcap_files: list[tuple[Path, str]],
     output_path: Path,
     max_workers: int | None = None,
+    topics_to_skip: list[str] | None = None,
+    process_stage1: bool = True,
+    process_stage2: bool = True,
+    stage1_dir: str | Path = "a1_one_to_one",
+    stage2_dir: str | Path = "a2_unpacked",
 ) -> None:
-    """Process MCAP files in parallel using ProcessPoolExecutor."""
+    """
+    Process MCAP files in parallel using ProcessPoolExecutor.
+
+    Args:
+        mcap_files: List of (file_path, group) tuples to process
+        output_path: Base output directory
+        max_workers: Number of parallel workers (default: CPU count - 1)
+        topics_to_skip: Optional list of topic names to skip during processing
+        process_stage1: If True, process and save stage 1 (one-to-one ROS message) output
+        process_stage2: If True, process and save stage 2 (unpacked arrays) output
+        stage1_dir: Directory name for stage 1 output (default: "a1_one_to_one")
+        stage2_dir: Directory name for stage 2 output (default: "a2_unpacked")
+    """
     if max_workers is None:
         # Use CPU count - 1 to leave one core free for system tasks
         max_workers = max(1, multiprocessing.cpu_count() - 1)
@@ -694,7 +749,16 @@ async def process_mcap_files_parallel(
         # Create tasks for all files
         futures = [
             loop.run_in_executor(
-                pool, process_single_file, mcap_file, group, output_path
+                pool,
+                process_single_file,
+                mcap_file,
+                group,
+                output_path,
+                topics_to_skip,
+                process_stage1,
+                process_stage2,
+                stage1_dir,
+                stage2_dir,
             )
             for mcap_file, group in mcap_files
         ]
@@ -710,15 +774,33 @@ async def process_mcap_files_parallel(
 
 
 def process_mcap_files(
-    input_dir: str, output_dir: str, async_processing: bool = False
+    input_dir: str,
+    output_dir: str,
+    async_processing: bool = False,
+    topics_to_skip: list[str] | None = None,
+    process_stage1: bool = True,
+    process_stage2: bool = True,
+    stage1_dir: str | Path = "a1_one_to_one",
+    stage2_dir: str | Path = "a2_unpacked",
 ) -> None:
     """
-    Process all MCAP files in a directory and its subdirectories with single read and dual output.
+    Process all MCAP files in a directory and its subdirectories
 
     Args:
         input_dir: Input directory containing MCAP files
         output_dir: Output directory for processed files
         async_processing: If True, process files in parallel using multiple CPU cores
+        topics_to_skip: Optional list of topic names to skip during processing
+        process_stage1: If True, process and save stage 1 output.
+                       Stage 1 preserves one-to-one ROS message structure where each row is
+                       a single ROS message. Array fields remain packed within rows.
+        process_stage2: If True, process and save stage 2 output.
+                       Stage 2 unpacks array fields into separate rows, where each array element
+                       becomes its own row. This format is recommended for analysis as it follows
+                       tidy data principles: each variable is a column, each observation is a row,
+                       and each value is a single cell.
+        stage1_dir: Directory name for stage 1 output (default: "a1_one_to_one")
+        stage2_dir: Directory name for stage 2 output (default: "a2_unpacked")
     """
     input_path = Path(input_dir)
     output_path = Path(output_dir)
@@ -738,7 +820,17 @@ def process_mcap_files(
 
     if async_processing:
         try:
-            asyncio.run(process_mcap_files_parallel(mcap_files, output_path))
+            asyncio.run(
+                process_mcap_files_parallel(
+                    mcap_files,
+                    output_path,
+                    topics_to_skip=topics_to_skip,
+                    process_stage1=process_stage1,
+                    process_stage2=process_stage2,
+                    stage1_dir=stage1_dir,
+                    stage2_dir=stage2_dir,
+                )
+            )
         except KeyboardInterrupt:
             logger.warning("\nProcessing interrupted by user")
             return
@@ -746,7 +838,16 @@ def process_mcap_files(
         # Sequential processing
         for mcap_file, group in mcap_files:
             try:
-                process_single_file(mcap_file, group, output_path)
+                process_single_file(
+                    mcap_file,
+                    group,
+                    output_path,
+                    topics_to_skip=topics_to_skip,
+                    process_stage1=process_stage1,
+                    process_stage2=process_stage2,
+                    stage1_dir=stage1_dir,
+                    stage2_dir=stage2_dir,
+                )
             except KeyboardInterrupt:
                 logger.warning("\nProcessing interrupted by user")
                 return

--- a/src/modaq_toolkit/parser.py
+++ b/src/modaq_toolkit/parser.py
@@ -72,11 +72,12 @@ class MCAPParser:
         1.0  # Threshold for timing misalignment warnings
     )
 
-    def __init__(self, mcap_path: Path):
+    def __init__(self, mcap_path: Path, topics_to_skip: list[str] | None = None):
         self.mcap_path = mcap_path
         self.processors: dict[str, MessageProcessor] = {}
         self.schemas_by_topic: dict[str, dict] = {}
         self.dataframes: dict[str, pd.DataFrame] = {}
+        self.topics_to_skip = topics_to_skip if topics_to_skip else []
 
     def _process_channel(self, channel, schema, summary) -> None:
         """Process a single channel from the MCAP file."""
@@ -123,10 +124,11 @@ class MCAPParser:
 
             # Create dataframes
             for topic, processor in self.processors.items():
-                self.dataframes[topic] = processor.get_dataframe()
-                logger.debug(
-                    f"Topic {topic} DataFrame shape: {self.dataframes[topic].shape}"
-                )
+                if topic not in self.topics_to_skip:
+                    self.dataframes[topic] = processor.get_dataframe()
+                    logger.info(
+                        f"Topic {topic} DataFrame shape: {self.dataframes[topic].shape}"
+                    )
 
     def _process_dataframe_for_stage2(
         self, df: pd.DataFrame

--- a/src/modaq_toolkit/parser.py
+++ b/src/modaq_toolkit/parser.py
@@ -268,8 +268,17 @@ class MCAPParser:
 
         # Process for stage 2 (expand arrays, add time index, etc.)
         for topic, df in non_empty_topics.items():
+            logger.info(
+                f"Processing dataframe for topic: {topic} with shape {df.shape}"
+            )
             processed_df, _ = self._process_dataframe_for_stage2(df.copy())
-            result[topic] = processed_df
+            logger.info(f"  Stage 2 Processed DataFrame shape: {processed_df.shape}")
+
+            # Only include non-empty DataFrames in result
+            if not processed_df.empty:
+                result[topic] = processed_df
+            else:
+                logger.warning(f"Topic {topic} became empty after stage 2 processing, excluding from results")
 
         return result
 

--- a/src/modaq_toolkit/parser.py
+++ b/src/modaq_toolkit/parser.py
@@ -530,7 +530,9 @@ def get_mcap_files(input_path: Path) -> list[tuple[Path, str]]:
 
 
 def process_mcap_and_get_dataframes(
-    mcap_file: Path, process_stage2: bool = False
+    mcap_file: Path,
+    process_stage2: bool = True,
+    topics_to_skip: list[str] | None = None,
 ) -> dict[str, pd.DataFrame]:
     """
     Process a single MCAP file and return the dataframes without saving to disk.
@@ -538,6 +540,7 @@ def process_mcap_and_get_dataframes(
     Args:
         mcap_file: Path to the MCAP file
         process_stage2: If True, process dataframes for stage 2 (expand arrays, etc.)
+        topics_to_skip: Optional list of topic names to skip during processing
 
     Returns:
         A dictionary with topic names as keys and processed dataframes as values
@@ -545,7 +548,7 @@ def process_mcap_and_get_dataframes(
 
     logger.info(f"Processing file {mcap_file.name} for in-memory access")
 
-    parser = MCAPParser(mcap_file)
+    parser = MCAPParser(mcap_file, topics_to_skip=topics_to_skip)
     parser.read_mcap()
 
     # Get dataframes with or without stage 2 processing

--- a/src/modaq_toolkit/parser.py
+++ b/src/modaq_toolkit/parser.py
@@ -157,10 +157,15 @@ class MCAPParser:
             time_diffs = df.index.to_series().diff().dt.total_seconds()
             return df, 1 / time_diffs.mean()
         else:
-            df["time"] = pd.to_datetime(
-                df["timestamp"], origin="unix", unit="s", utc=True
-            )
-            df = df.set_index("time")
+            if "timestamp" not in df.columns:
+                logger.warning(
+                    f"No 'timestamp' column found for stage 2 processing on non-array data. Skipping inclusion of time index. Valid columns are {df.columns.tolist()}"
+                )
+            else:
+                df["time"] = pd.to_datetime(
+                    df["timestamp"], origin="unix", unit="s", utc=True
+                )
+                df = df.set_index("time")
             return df, None
 
     def _get_topic_timing(self, df: pd.DataFrame) -> TopicTiming:

--- a/src/modaq_toolkit/parser.py
+++ b/src/modaq_toolkit/parser.py
@@ -138,7 +138,7 @@ class MCAPParser:
         self,
         df: pd.DataFrame,
         convert_ros_time_to_utc_datetime_index: bool = True,
-        remove_original_extra_time_columns: bool = True,
+        remove_original_extra_time_columns: bool = False,
     ) -> tuple[pd.DataFrame, float]:
         """Process a dataframe for stage 2, returning the processed df and sample rate."""
         # Early exit for empty DataFrame

--- a/src/modaq_toolkit/parser.py
+++ b/src/modaq_toolkit/parser.py
@@ -556,7 +556,10 @@ def process_mcap_and_get_dataframes(
 
 
 def process_mcap_dir_to_dataframes(
-    input_dir: Path, process_stage2: bool = True, concat_by_topic: bool = True
+    input_dir: Path,
+    process_stage2: bool = True,
+    concat_by_topic: bool = True,
+    topics_to_skip: list[str] | None = None,
 ) -> dict[str, dict[str, pd.DataFrame] | pd.DataFrame]:
     """
     Process all MCAP files in a directory and return them as a dictionary
@@ -567,6 +570,7 @@ def process_mcap_dir_to_dataframes(
         process_stage2: If True, process dataframes with stage 2 processing
         concat_by_topic: If True, concatenate all dataframes for each topic within a group
                         If False, return a dictionary of dataframes per topic
+        topics_to_skip: Optional list of topic names to skip during processing
 
     Returns:
         A dictionary where:
@@ -600,7 +604,9 @@ def process_mcap_dir_to_dataframes(
     # Process each file
     for mcap_file, group_name in mcap_files:
         # Get dataframes from current file
-        topic_dfs = process_mcap_and_get_dataframes(mcap_file, process_stage2)
+        topic_dfs = process_mcap_and_get_dataframes(
+            mcap_file, process_stage2, topics_to_skip=topics_to_skip
+        )
 
         # Skip if no dataframes were found
         if not topic_dfs:

--- a/src/modaq_toolkit/parser.py
+++ b/src/modaq_toolkit/parser.py
@@ -134,11 +134,20 @@ class MCAPParser:
         self, df: pd.DataFrame
     ) -> tuple[pd.DataFrame, float]:
         """Process a dataframe for stage 2, returning the processed df and sample rate."""
+        # Early exit for empty DataFrame
+        if df.empty:
+            return df, None
+
         object_columns = [col for col in df.columns if is_array_column(df[col])]
 
         if object_columns:
             logger.debug("Found arrays, expanding for a2 processing")
             df = expand_array_columns_vertically(df)
+
+            # If all rows were skipped during expansion, return empty DataFrame
+            if df.empty:
+                return df, None
+
             df["time"] = pd.to_datetime(
                 df["system_time"], origin="unix", unit="ns", utc=True
             )

--- a/src/modaq_toolkit/parser.py
+++ b/src/modaq_toolkit/parser.py
@@ -288,7 +288,7 @@ class MCAPParser:
         self,
         process_stage2: bool = False,
         stage_2_convert_ros_time_to_utc_datetime_index: bool = True,
-        stage_2_remove_original_extra_time_columns: bool = True,
+        stage_2_remove_original_extra_time_columns: bool = False,
     ) -> dict[str, pd.DataFrame]:
         """
         Return a dictionary of processed dataframes without saving to disk.

--- a/src/modaq_toolkit/parser.py
+++ b/src/modaq_toolkit/parser.py
@@ -78,6 +78,7 @@ class MCAPParser:
         self.schemas_by_topic: dict[str, dict] = {}
         self.dataframes: dict[str, pd.DataFrame] = {}
         self.topics_to_skip = topics_to_skip if topics_to_skip else []
+        self._processed = False  # Track whether read_mcap() has been called
 
     def _process_channel(self, channel, schema, summary) -> None:
         """Process a single channel from the MCAP file."""
@@ -129,6 +130,9 @@ class MCAPParser:
                     logger.info(
                         f"Topic {topic} DataFrame shape: {self.dataframes[topic].shape}"
                     )
+
+        # Mark as processed
+        self._processed = True
 
     def _process_dataframe_for_stage2(
         self,
@@ -289,6 +293,8 @@ class MCAPParser:
         """
         Return a dictionary of processed dataframes without saving to disk.
 
+        Automatically calls read_mcap() if it hasn't been called yet.
+
         Args:
             process_stage2: If True, process dataframes for stage 2 (expand arrays, etc.)
             stage_2_convert_ros_time_to_utc_datetime_index: If True, convert ROS time (sec,nanosec) to UTC datetime index
@@ -298,6 +304,10 @@ class MCAPParser:
         Returns:
             A dictionary with topic names as keys and processed dataframes as values
         """
+        # Auto-call read_mcap() if not yet processed
+        if not self._processed:
+            self.read_mcap()
+
         result = {}
 
         # Filter out empty dataframes
@@ -332,7 +342,15 @@ class MCAPParser:
         return result
 
     def create_output(self, output_dir: Path, stage: str = "a1_one_to_one") -> None:
-        """Create partitioned parquet files and metadata JSON for each topic."""
+        """
+        Create partitioned parquet files and metadata JSON for each topic.
+
+        Automatically calls read_mcap() if it hasn't been called yet.
+        """
+        # Auto-call read_mcap() if not yet processed
+        if not self._processed:
+            self.read_mcap()
+
         stage_dir = output_dir / stage
         metadata_dir = output_dir / "metadata"
         stage_dir.mkdir(parents=True, exist_ok=True)

--- a/src/modaq_toolkit/parser.py
+++ b/src/modaq_toolkit/parser.py
@@ -278,7 +278,9 @@ class MCAPParser:
             if not processed_df.empty:
                 result[topic] = processed_df
             else:
-                logger.warning(f"Topic {topic} became empty after stage 2 processing, excluding from results")
+                logger.warning(
+                    f"Topic {topic} became empty after stage 2 processing, excluding from results"
+                )
 
         return result
 


### PR DESCRIPTION
This PR improves the modaq_toolkit MCAP parser's robustness when handling edge cases in ROS2 message processing, adds flexible topic filtering, and enhances type conversion from ROS to numpy data types.

## New Features

### 1. Topic Filtering with `topics_to_skip`

The `MCAPParser` now accepts an optional `topics_to_skip` parameter that allows you to exclude specific topics from processing:

```python
from modaq_toolkit import MCAPParser
from pathlib import Path

# Skip specific topics during parsing
parser = MCAPParser(
    mcap_path=Path("my_bag.mcap"),
    topics_to_skip=["/diagnostics", "/rosout", "/parameter_events"]
)

# Process the file - skipped topics won't appear in output
dataframes = parser.get_dataframes()
```

### 2. Automatic ROS Constants Filtering

The parser now automatically skips ROS message constant definitions (which are not actual message fields). These include common logging level constants like:

- `DEBUG=10`
- `INFO=20`
- `WARN=30`
- `ERROR=40`
- `FATAL=50`

These constants appear in ROS message schemas but aren't data fields. Previously, the parser would try to extract these as fields and fail. Now they're automatically detected and skipped during schema parsing.

### 3. ROS to Numpy Type Conversion

The `MessageProcessor` now includes a type mapping system (`ros_type_to_numpy_type_map`) that converts ROS primitive types to their corresponding numpy dtypes:

```python
ros_type_to_numpy_type_map = {
    "float64": np.float64,
    # Additional mappings can be added for int8, int16, int32, float32, etc.
}
```

When processing messages, fields with recognized ROS types are automatically converted to numpy arrays with the correct dtype:
- Explicitly specifies precision based on MCAP schema (e.g., uint64 remains uint64, not automatically converted to int64).
- `mcap list schema <path_to_mcap>` provides schema output in cli for reference
